### PR TITLE
Parameter handling improvements.

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -1,18 +1,41 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: A Serverless Application to demo Cloud One Application Security.
+
 Parameters:
   C1RegionEndpoint:
     Type: String
-    Default: ""
+    Default: "https://agents.us-1.application.cloudone.trendmicro.com/"
     Description: Enter the Cloud One Account Region Endpoint.
   AppSecKey:
     Type: String
     Default: ""
-    Description: Enter the Security Group Key.
+    Description: Enter the Security Group Key. You can find it at https://cloudone.trendmicro.com/application#/policies
   AppSecSecret:
     Type: String
     Default: ""
-    Description: Enter the Security Group Secret.
+    Description: Enter the Security Group Secret. You can find it at https://cloudone.trendmicro.com/application#/policies
+
+Metadata: 
+  AWS::CloudFormation::Interface: 
+    ParameterGroups: 
+      - 
+        Label: 
+          default: "Security Group Data"
+        Parameters: 
+          - AppSecKey
+          - AppSecSecret
+      - 
+        Label: 
+          default: "Cloud One Regional Setting"
+        Parameters: 
+          - C1RegionEndpoint
+    ParameterLabels:
+      C1RegionEndpoint:
+        default: Cloud One Account Region Endpoint. Defaults to https://agents.us-1.application.cloudone.trendmicro.com/
+      AppSecKey:
+        default: Security Group Key
+      AppSecSecret:
+        default: Security Group Secret
 
 Resources:
 


### PR DESCRIPTION
Since the guide suggests a specific `C1RegionEndpoint`, I added it as a default so it gets auto-populated and reduces the chance of user error.

And since I was trying to avoid user error, I separated the parameters in 2 groups: Security Group specific and Cloud One Region specific.

You can see the final result below:
<img width="1155" alt="Screen Shot 2022-06-14 at 4 30 00 PM" src="https://user-images.githubusercontent.com/472728/173692990-2b0647f5-f52a-411c-b710-318a9a6acb21.png">
 